### PR TITLE
Add security tooling tasks

### DIFF
--- a/foundry/foundry.toml
+++ b/foundry/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+test = 'test'

--- a/foundry/test/CometFuzz.t.sol
+++ b/foundry/test/CometFuzz.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+
+interface IComet {
+    function supply(address asset, uint256 amount) external;
+}
+
+contract CometFuzz is Test {
+    address constant COMET = 0xc3d688B66703497DAA19211EEdff47f25384cdc3;
+    address constant USDC  = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48;
+
+    function setUp() public {
+        string memory rpc = vm.envOr("MAINNET_RPC_URL", "");
+        vm.createSelectFork(rpc, 19100000);
+    }
+
+    function testFuzzSupply(uint256 amount) public {
+        amount = bound(amount, 1, 1_000_000e6);
+        vm.assume(amount > 0);
+        IComet comet = IComet(COMET);
+        // placeholder: would call comet.supply(USDC, amount);
+        assertTrue(amount <= 1_000_000e6);
+    }
+}

--- a/packages/hardhat-comet/README.md
+++ b/packages/hardhat-comet/README.md
@@ -115,7 +115,7 @@ export default config;
   npx hardhat setup-comet-env --network hardhat
   ```
 
-- **`fork-network`**  
+- **`fork-network`**
   Forks a network at a specific block (or latest) to create a local testing environment.
 
   **Usage:**
@@ -128,6 +128,24 @@ export default config;
 
    ```bash
   npx hardhat fork-network --network hardhat --block-number 17000000
+  ```
+
+- **`slither`**
+  Runs [Slither](https://github.com/crytic/slither) static analysis on the custom contracts in `packages/scenarios`.
+
+  **Usage:**
+
+  ```bash
+  npx hardhat slither
+  ```
+
+- **`forge-fuzz`**
+  Executes Foundry based fuzz tests found under the `foundry/test` directory.
+
+  **Usage:**
+
+  ```bash
+  npx hardhat forge-fuzz
   ```
 
 

--- a/packages/hardhat-comet/src/index.ts
+++ b/packages/hardhat-comet/src/index.ts
@@ -37,6 +37,8 @@ import "./tasks/setup";
 import "./tasks/fork";
 import "./tasks/tokens";
 import "./tasks/print-config";
+import "./tasks/slither";
+import "./tasks/fuzz";
 
 
 

--- a/packages/hardhat-comet/src/tasks/fuzz.ts
+++ b/packages/hardhat-comet/src/tasks/fuzz.ts
@@ -1,0 +1,13 @@
+import { task } from "hardhat/config";
+import path from "path";
+import { execSync } from "child_process";
+
+task("forge-fuzz", "Run Foundry fuzz tests")
+  .addOptionalParam("pattern", "Test pattern to run", "")
+  .setAction(async (args, hre) => {
+    const foundryDir = path.resolve(hre.config.paths.root, "foundry");
+    const pat = args.pattern ? `--match-test ${args.pattern}` : "";
+    const cmd = `forge test -vv ${pat}`;
+    console.log(`Running: ${cmd} in ${foundryDir}`);
+    execSync(cmd, { stdio: "inherit", cwd: foundryDir });
+  });

--- a/packages/hardhat-comet/src/tasks/slither.ts
+++ b/packages/hardhat-comet/src/tasks/slither.ts
@@ -1,0 +1,10 @@
+import { task } from "hardhat/config";
+import path from "path";
+import { execSync } from "child_process";
+
+task("slither", "Run Slither static analysis on custom contracts").setAction(async (_, hre) => {
+  const contractsDir = path.resolve(hre.config.paths.root, "packages", "scenarios", "contracts");
+  const cmd = `slither ${contractsDir} --ignore-compile --print human-summary`;
+  console.log(`Running: ${cmd}`);
+  execSync(cmd, { stdio: "inherit" });
+});


### PR DESCRIPTION
## Summary
- add new Hardhat tasks for slither and forge fuzzing
- register tasks with plugin
- document tasks in README
- scaffold foundry project with sample fuzz test

## Testing
- `npm test --workspaces` *(fails: JsonRpcProvider failed to detect network)*

------
https://chatgpt.com/codex/tasks/task_e_6852ac0db8f4832797a0a60b6a0132f4