### PR TITLE
Fix high severity issues

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,8 +77,9 @@ import App from './App';
 import { Comet } from '@comet-devx/sdk';
 import { ethers } from 'ethers';
 
-const provider = new ethers.providers.JsonRpcProvider("https://sepolia.infura.io/v3/YOUR_INFURA_KEY");
-const wallet = new ethers.Wallet("0xYOUR_PRIVATE_KEY", provider);
+// Use environment variables for sensitive information
+const provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL ?? "");
+const wallet = new ethers.Wallet(process.env.PRIVATE_KEY as string, provider);
 const comet = new Comet("sepolia", wallet);
 
 console.log("Comet instance:", comet);
@@ -170,8 +171,9 @@ import { Comet } from "@comet-devx/sdk";
 
 async function main() {
   // Example configuration - update with your actual RPC provider and private key.
-  const provider = new ethers.providers.JsonRpcProvider("https://sepolia.infura.io/v3/YOUR_INFURA_KEY");
-  const wallet = new ethers.Wallet("0xYOUR_PRIVATE_KEY", provider);
+  // Use environment variables for sensitive information
+  const provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL ?? "");
+  const wallet = new ethers.Wallet(process.env.PRIVATE_KEY as string, provider);
   const comet = new Comet("sepolia", wallet);
 
   console.log("Comet instance created:", comet);

--- a/packages/hardhat-comet/hardhat.config.ts
+++ b/packages/hardhat-comet/hardhat.config.ts
@@ -2,17 +2,18 @@ import "@nomicfoundation/hardhat-ethers";
 import "./src/index"; // Tells Hardhat to load everything from the plugin entry point
 import { HardhatUserConfig } from "hardhat/types";
 
+const infuraKey = process.env.INFURA_API_KEY || "";
 const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   networks: {
     hardhat: {
       forking: {
-        url: "https://mainnet.infura.io/v3/aba547734f7640bb85673cccedd201b1",
+        url: `https://mainnet.infura.io/v3/${infuraKey}`,
         // blockNumber: 17000000 // optional
       }
     },
     mainnet: {
-      url: "https://mainnet.infura.io/v3/aba547734f7640bb85673cccedd201b1"
+      url: `https://mainnet.infura.io/v3/${infuraKey}`
     }
   },
   solidity: "0.8.17"

--- a/packages/python-sdk/src/comet_devx/comet.py
+++ b/packages/python-sdk/src/comet_devx/comet.py
@@ -86,6 +86,7 @@ class Comet:
         self,
         asset: ChecksumAddress,
         amount: Wei,
+        private_key: str,
         config: Optional[TransactionConfig] = None
     ) -> TxReceipt:
         """
@@ -94,6 +95,7 @@ class Comet:
         Args:
             asset: The ERC20 token address to supply
             amount: Amount to supply (in smallest units)
+            private_key: Hex string of the sender's private key
             config: Optional transaction configuration
 
         Returns:
@@ -121,7 +123,7 @@ class Comet:
             # Real transaction handling
             signed_tx = self.web3.eth.account.sign_transaction(
                 tx,
-                private_key=self.web3.eth.account._private_key
+                private_key=private_key
             )
             tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
             return self.web3.eth.wait_for_transaction_receipt(tx_hash)
@@ -134,6 +136,7 @@ class Comet:
     async def borrow(
         self,
         amount: Wei,
+        private_key: str,
         config: Optional[TransactionConfig] = None
     ) -> TxReceipt:
         """
@@ -141,6 +144,7 @@ class Comet:
 
         Args:
             amount: Amount to borrow (in smallest units)
+            private_key: Hex string of the sender's private key
             config: Optional transaction configuration
 
         Returns:
@@ -170,7 +174,7 @@ class Comet:
             # Real transaction handling
             signed_tx = self.web3.eth.account.sign_transaction(
                 tx,
-                private_key=self.web3.eth.account._private_key
+                private_key=private_key
             )
             tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
             return self.web3.eth.wait_for_transaction_receipt(tx_hash)
@@ -183,6 +187,7 @@ class Comet:
     async def repay(
         self,
         amount: Wei,
+        private_key: str,
         config: Optional[TransactionConfig] = None
     ) -> TxReceipt:
         """
@@ -190,6 +195,7 @@ class Comet:
 
         Args:
             amount: Amount to repay (in smallest units)
+            private_key: Hex string of the sender's private key
             config: Optional transaction configuration
 
         Returns:
@@ -219,7 +225,7 @@ class Comet:
             # Real transaction handling
             signed_tx = self.web3.eth.account.sign_transaction(
                 tx,
-                private_key=self.web3.eth.account._private_key
+                private_key=private_key
             )
             tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
             return self.web3.eth.wait_for_transaction_receipt(tx_hash)

--- a/packages/python-sdk/tests/test_comet.py
+++ b/packages/python-sdk/tests/test_comet.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock, patch
 from comet_devx.comet import Comet
 from comet_devx.types import CometException, InsufficientFundsError
 
+TEST_KEY = "0x59c6995e998f97a5a0044966f09453894be93910e1f9d6b9961c6ff93d5d56e9"
+
 @pytest.fixture
 def web3_mock():
     """Create a mock Web3 instance."""
@@ -61,7 +63,8 @@ async def test_supply(comet, web3_mock, mock_tx_receipt):
     # Test successful supply
     result = await comet.supply(
         "0x1234567890123456789012345678901234567890",
-        Wei(1000000)
+        Wei(1000000),
+        TEST_KEY
     )
     
     assert result == mock_tx_receipt
@@ -89,7 +92,7 @@ async def test_borrow(comet, web3_mock, mock_tx_receipt):
     web3_mock.eth.wait_for_transaction_receipt = Mock(return_value=mock_tx_receipt)
 
     # Test successful borrow
-    result = await comet.borrow(Wei(1000000))
+    result = await comet.borrow(Wei(1000000), TEST_KEY)
     
     assert result == mock_tx_receipt
     comet.contract.functions.withdraw.assert_called_once()
@@ -116,7 +119,7 @@ async def test_repay(comet, web3_mock, mock_tx_receipt):
     web3_mock.eth.wait_for_transaction_receipt = Mock(return_value=mock_tx_receipt)
 
     # Test successful repay
-    result = await comet.repay(Wei(1000000))
+    result = await comet.repay(Wei(1000000), TEST_KEY)
     
     assert result == mock_tx_receipt
     comet.contract.functions.supply.assert_called_once()
@@ -133,5 +136,6 @@ async def test_supply_insufficient_funds(comet, web3_mock):
     with pytest.raises(InsufficientFundsError):
         await comet.supply(
             "0x1234567890123456789012345678901234567890",
-            Wei(1000000)
+            Wei(1000000),
+            TEST_KEY
         )

--- a/packages/sdk/test/Comet.spec.ts
+++ b/packages/sdk/test/Comet.spec.ts
@@ -6,14 +6,12 @@ describe("Comet SDK Core Methods", () => {
   let comet: Comet;
 
   beforeAll(() => {
-    // Use a dummy provider, or direct it to a local test RPC if you want.
-    const provider = new ethers.JsonRpcProvider("https://arb-sepolia.g.alchemy.com/v2/WU4lUat2tzS281NCprT48LqOSpONW1nY");
-     // Create a test wallet with a private key (for local tests)
-       // Replace the 0xDEADBEEF... with any valid private key
-    const wallet = new ethers.Wallet("024b201993dbc4f5f4b328e8b75d106e3520eed6d7279844a07299193906bbc3", provider);
+    const provider = new ethers.JsonRpcProvider();
+    const wallet = new ethers.Wallet("0x59c6995e998f97a5a0044966f09453894be93910e1f9d6b9961c6ff93d5d56e9", provider);
 
     // Create our Comet instance, referencing 'sepolia' from your config
     comet = new Comet("sepolia", wallet);
+    (comet as any).contract.supply = jest.fn().mockResolvedValue({});
   });
 
   // it("should have a supply method that returns a promise", async () => {
@@ -26,8 +24,8 @@ describe("Comet SDK Core Methods", () => {
   //   expect(txPromise).toBeInstanceOf(Promise);
   // });
 
-  it("should have a repay method that returns a promise", async () => {
-    const txPromise = await comet.repay(200);
+  it("should have a repay method that returns a promise", () => {
+    const txPromise = comet.repay(200);
     expect(txPromise).toBeInstanceOf(Promise);
   });
 });


### PR DESCRIPTION
## Summary
- remove example secrets from create-comet-app templates
- load Infura key from environment in Hardhat config
- mock provider and wallet in SDK tests
- accept private key as parameter for python library methods
- adjust unit tests for Python SDK

## Testing
- `npm run test --workspace=@comet-devx/sdk`
- `pytest packages/python-sdk/tests`

------
https://chatgpt.com/codex/tasks/task_e_6852b5b3c35c83279a6a7063cae6f048